### PR TITLE
refactor!: single import pattern module exports + update docs

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -3,7 +3,6 @@ import { defineBuildConfig } from "unbuild";
 export default defineBuildConfig({
   declaration: true,
   entries: [
-    "./src/mailchannels",
-    "./src/modules"
+    "./src/mailchannels"
   ]
 });

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -51,8 +51,7 @@ This method is useful when building an application on top of MailChannels and yo
 In this example, we import the `MailChannelsClient` and the `Emails` module to send an email.
 
 ```ts{1,2}
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Emails } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Emails } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const emails = new Emails(mailchannels)

--- a/docs/modules/domains.md
+++ b/docs/modules/domains.md
@@ -16,8 +16,7 @@ Provision a single domain to use MailChannels Inbound.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Domains } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Domains } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const domains = new Domains(mailchannels)
@@ -30,6 +29,7 @@ const { data } = await domains.provision({
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { data } = await mailchannels.domains.provision({
@@ -90,8 +90,7 @@ Provision up to 1000 domains to use MailChannels Inbound.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Domains } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Domains } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const domains = new Domains(mailchannels)
@@ -106,6 +105,7 @@ const { results } = await domains.bulkProvision({
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { results } = await mailchannels.domains.bulkProvision({
@@ -191,8 +191,7 @@ Fetch a list of all domains associated with this API key.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Domains } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Domains } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const domains = new Domains(mailchannels)
@@ -202,6 +201,7 @@ const { domains: domainsList } = await domains.list()
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { domains } = await mailchannels.domains.list()
@@ -245,8 +245,7 @@ De-provision a domain to cease protecting it with MailChannels Inbound.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Domains } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Domains } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const domains = new Domains(mailchannels)
@@ -256,6 +255,7 @@ const { success } = await domains.delete('example.com')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.domains.delete('example.com')
@@ -279,8 +279,7 @@ Add an entry to a domain blocklist or safelist.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Domains } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Domains } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const domains = new Domains(mailchannels)
@@ -293,6 +292,7 @@ const { entry } = await domains.addListEntry('example.com', {
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { entry } = await mailchannels.domains.addListEntry('example.com', {
@@ -325,8 +325,7 @@ Get domain list entries.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Domains } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Domains } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const domains = new Domains(mailchannels)
@@ -336,6 +335,7 @@ const { entries } = await domains.listEntries('example.com', 'safelist')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { entries } = await mailchannels.domains.listEntries('example.com', 'safelist')
@@ -363,8 +363,7 @@ Delete item from domain list.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Domains } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Domains } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const domains = new Domains(mailchannels)
@@ -377,6 +376,7 @@ const { success } = await domains.deleteListEntry('example.com', {
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.domains.deleteListEntry('example.com', {
@@ -406,8 +406,7 @@ Generate a link that allows a user to log in as a domain administrator.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Domains } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Domains } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const domains = new Domains(mailchannels)
@@ -417,6 +416,7 @@ const { link } = await domains.createLoginLink("example.com")
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { link } = await mailchannels.domains.createLoginLink("example.com")
@@ -443,8 +443,7 @@ Sets the list of downstream addresses for the domain.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Domains } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Domains } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const domains = new Domains(mailchannels)
@@ -461,6 +460,7 @@ const { success } = await domains.setDownstreamAddress('example.com', [
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.domains.setDownstreamAddress('example.com', [
@@ -498,8 +498,7 @@ Retrieve stored downstream addresses for the domain.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Domains } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Domains } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const domains = new Domains(mailchannels)
@@ -509,6 +508,7 @@ const { records } = await domains.listDownstreamAddresses('example.com')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { records } = await mailchannels.domains.listDownstreamAddresses('example.com')
@@ -541,8 +541,7 @@ Update the API key that is associated with a domain.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Domains } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Domains } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const domains = new Domains(mailchannels)
@@ -552,6 +551,7 @@ const { success } = await domains.updateApiKey('example.com', 'your-api-key')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.domains.updateApiKey('example.com', 'your-api-key')
@@ -576,8 +576,7 @@ Generate a batch of links that allow a user to log in as a domain administrator 
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Domains } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Domains } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const domains = new Domains(mailchannels)
@@ -590,6 +589,7 @@ const { results } = await domains.bulkCreateLoginLinks([
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { results } = await mailchannels.domains.bulkCreateLoginLinks([

--- a/docs/modules/emails.md
+++ b/docs/modules/emails.md
@@ -16,8 +16,7 @@ Sends an email message to one or more recipients.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Emails } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Emails } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const emails = new Emails(mailchannels)
@@ -33,6 +32,7 @@ const { success, data } = await emails.send({
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success, data } = await mailchannels.emails.send({
@@ -116,8 +116,7 @@ Validates a domain's email authentication setup by retrieving its DKIM, SPF, and
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Emails } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Emails } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const emails = new Emails(mailchannels)
@@ -135,6 +134,7 @@ const { results } = await emails.checkDomain({
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.emails.checkDomain({
@@ -202,8 +202,7 @@ Create a DKIM key pair for a specified domain and selector using the specified a
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Emails } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Emails } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const emails = new Emails(mailchannels)
@@ -215,6 +214,7 @@ const { key } = await emails.createDkimKey('example.com', {
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { key } = await mailchannels.emails.createDkimKey('example.com', {
@@ -259,8 +259,7 @@ Search for DKIM keys by customer handle and domain, with optional filters. If se
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Emails } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Emails } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const emails = new Emails(mailchannels)
@@ -272,6 +271,7 @@ const { keys } = await emails.getDkimKeys('example.com', {
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { keys } = await mailchannels.emails.getDkimKeys('example.com', {
@@ -317,8 +317,7 @@ Update fields of an existing DKIM key pair for the specified domain and selector
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Emails } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Emails } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const emails = new Emails(mailchannels)
@@ -331,6 +330,7 @@ const { success } = await emails.updateDkimKey('example.com', {
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.emails.updateDkimKey('example.com', {

--- a/docs/modules/lists.md
+++ b/docs/modules/lists.md
@@ -16,8 +16,7 @@ Add an entry to an account-level blocklist or safelist.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Lists } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Lists } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const lists = new Lists(mailchannels)
@@ -30,6 +29,7 @@ const { entry } = await lists.addListEntry({
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { entry } = await mailchannels.lists.addListEntry({
@@ -61,8 +61,7 @@ Get account-level list entries.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Lists } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Lists } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const lists = new Lists(mailchannels)
@@ -72,6 +71,7 @@ const { entries } = await lists.listEntries('safelist')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { entries } = await mailchannels.lists.listEntries('safelist')
@@ -98,8 +98,7 @@ Delete item from account-level list.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Lists } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Lists } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const lists = new Lists(mailchannels)
@@ -112,6 +111,7 @@ const { success } = await lists.deleteListEntry({
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.lists.deleteListEntry({

--- a/docs/modules/metrics.md
+++ b/docs/modules/metrics.md
@@ -16,8 +16,7 @@ Retrieve engagement metrics for messages sent from your account, including count
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Metrics } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Metrics } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const metrics = new Metrics(mailchannels)
@@ -27,6 +26,7 @@ const { engagement } = await metrics.engagement()
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { engagement } = await mailchannels.metrics.engagement()
@@ -73,8 +73,7 @@ Retrieve performance metrics for messages sent from your account, including coun
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Metrics } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Metrics } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const metrics = new Metrics(mailchannels)
@@ -84,6 +83,7 @@ const { performance } = await metrics.performance()
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { performance } = await mailchannels.metrics.performance()
@@ -126,8 +126,7 @@ Retrieve recipient behaviour metrics for messages sent from your account, includ
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Metrics } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Metrics } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const metrics = new Metrics(mailchannels)
@@ -137,6 +136,7 @@ const { behaviour } = await metrics.recipientBehaviour()
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { behaviour } = await mailchannels.metrics.recipientBehaviour()
@@ -175,8 +175,7 @@ Retrieve volume metrics for messages sent from your account, including counts of
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Metrics } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Metrics } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const metrics = new Metrics(mailchannels)
@@ -186,6 +185,7 @@ const { volume } = await metrics.volume()
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { volume } = await mailchannels.metrics.volume()
@@ -228,8 +228,7 @@ Retrieves usage statistics during the current billing period.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Metrics } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Metrics } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const metrics = new Metrics(mailchannels)
@@ -239,6 +238,7 @@ const { usage } = await metrics.usage()
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { usage } = await mailchannels.metrics.usage()

--- a/docs/modules/service.md
+++ b/docs/modules/service.md
@@ -16,8 +16,7 @@ Retrieve the condition of the service.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Service } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Service } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const service = new Service(mailchannels)
@@ -27,6 +26,7 @@ const { success } = await service.status()
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.service.status()
@@ -45,8 +45,7 @@ Get a list of your subscriptions to MailChannels Inbound.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Service } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Service } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const service = new Service(mailchannels)
@@ -56,6 +55,7 @@ const { subscriptions } = await service.subscriptions()
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { subscriptions } = await mailchannels.service.subscriptions()
@@ -83,8 +83,7 @@ Submit a false negative or false positive report.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Service } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Service } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const service = new Service(mailchannels)
@@ -97,6 +96,7 @@ const { success } = await service.report({
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.service.report({

--- a/docs/modules/sub-accounts.md
+++ b/docs/modules/sub-accounts.md
@@ -15,8 +15,7 @@ Creates a new sub-account under the parent account.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { SubAccounts } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, SubAccounts } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const subAccounts = new SubAccounts(mailchannels)
@@ -26,6 +25,7 @@ const { account } = await subAccounts.create('My Company', 'validhandle123')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { account } = await mailchannels.subAccounts.create('My Company', 'validhandle123')
@@ -59,8 +59,7 @@ Retrieves all sub-accounts associated with the parent account.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { SubAccounts } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, SubAccounts } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const subAccounts = new SubAccounts(mailchannels)
@@ -70,6 +69,7 @@ const { accounts } = await subAccounts.list()
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { accounts } = await mailchannels.subAccounts.list()
@@ -100,8 +100,7 @@ Deletes the sub-account identified by its handle.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { SubAccounts } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, SubAccounts } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const subAccounts = new SubAccounts(mailchannels)
@@ -111,6 +110,7 @@ const { success } = await subAccounts.delete('validhandle123')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.subAccounts.delete('validhandle123')
@@ -134,8 +134,7 @@ Suspends the sub-account identified by its handle. This action disables the acco
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { SubAccounts } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, SubAccounts } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const subAccounts = new SubAccounts(mailchannels)
@@ -145,6 +144,7 @@ const { success } = await subAccounts.suspend('validhandle123')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.subAccounts.suspend('validhandle123')
@@ -168,8 +168,7 @@ Activates a suspended sub-account identified by its handle, restoring its abilit
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { SubAccounts } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, SubAccounts } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const subAccounts = new SubAccounts(mailchannels)
@@ -179,6 +178,7 @@ const { success } = await subAccounts.activate('validhandle123')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.subAccounts.activate('validhandle123')
@@ -202,8 +202,7 @@ Creates a new API key for the specified sub-account.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { SubAccounts } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, SubAccounts } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const subAccounts = new SubAccounts(mailchannels)
@@ -213,6 +212,7 @@ const { key } = await subAccounts.createApiKey('validhandle123')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { key } = await mailchannels.subAccounts.createApiKey('validhandle123')
@@ -238,8 +238,7 @@ Retrieves details of all API keys associated with the specified sub-account. For
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { SubAccounts } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, SubAccounts } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const subAccounts = new SubAccounts(mailchannels)
@@ -249,6 +248,7 @@ const { keys } = await subAccounts.listApiKeys('validhandle123')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { keys } = await mailchannels.subAccounts.listApiKeys('validhandle123')
@@ -279,8 +279,7 @@ Deletes the API key identified by its ID for the specified sub-account.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { SubAccounts } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, SubAccounts } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const subAccounts = new SubAccounts(mailchannels)
@@ -290,6 +289,7 @@ const { success } = await subAccounts.deleteApiKey('validhandle123', 1)
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.subAccounts.deleteApiKey('validhandle123', 1)
@@ -314,8 +314,7 @@ Creates a new API key for the specified sub-account.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { SubAccounts } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, SubAccounts } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const subAccounts = new SubAccounts(mailchannels)
@@ -325,6 +324,7 @@ const { password } = await subAccounts.createSmtpPassword('validhandle123')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { password } = await mailchannels.subAccounts.createSmtpPassword('validhandle123')
@@ -351,8 +351,7 @@ Retrieves details of all API keys associated with the specified sub-account. For
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { SubAccounts } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, SubAccounts } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const subAccounts = new SubAccounts(mailchannels)
@@ -362,6 +361,7 @@ const { keys } = await subAccounts.listSmtpPasswords('validhandle123')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { keys } = await mailchannels.subAccounts.listSmtpPasswords('validhandle123')
@@ -388,8 +388,7 @@ Deletes the SMTP password identified by its ID for the specified sub-account.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { SubAccounts } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, SubAccounts } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const subAccounts = new SubAccounts(mailchannels)
@@ -399,6 +398,7 @@ const { success } = await subAccounts.deleteSmtpPassword('validhandle123', 1)
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.subAccounts.deleteSmtpPassword('validhandle123', 1)
@@ -426,8 +426,7 @@ Retrieves the limit of a specified sub-account.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { SubAccounts } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, SubAccounts } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const subAccounts = new SubAccounts(mailchannels)
@@ -437,6 +436,7 @@ const { limit } = await subAccounts.getLimit('validhandle123')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { limit } = await mailchannels.subAccounts.getLimit('validhandle123')
@@ -461,8 +461,7 @@ Sets the limit for the specified sub-account.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { SubAccounts } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, SubAccounts } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const subAccounts = new SubAccounts(mailchannels)
@@ -472,6 +471,7 @@ const { success } = await subAccounts.setLimit('validhandle123', { sends: 1000 }
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.subAccounts.setLimit('validhandle123', { sends: 1000 })
@@ -499,8 +499,7 @@ Deletes the limit for the specified sub-account. After a successful deletion, th
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { SubAccounts } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, SubAccounts } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const subAccounts = new SubAccounts(mailchannels)
@@ -510,6 +509,7 @@ const { success } = await subAccounts.deleteLimit('validhandle123')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.subAccounts.deleteLimit('validhandle123')
@@ -533,8 +533,7 @@ Retrieves usage statistics for the specified sub-account during the current bill
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { SubAccounts } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, SubAccounts } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const subAccounts = new SubAccounts(mailchannels)
@@ -544,6 +543,7 @@ const { usage } = await subAccounts.getUsage('validhandle123')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { usage } = await mailchannels.subAccounts.getUsage('validhandle123')

--- a/docs/modules/suppressions.md
+++ b/docs/modules/suppressions.md
@@ -16,8 +16,7 @@ Creates suppression entries for the specified account. Parent accounts can creat
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Suppressions } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Suppressions } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const suppressions = new Suppressions(mailchannels)
@@ -36,6 +35,7 @@ const { success } = await suppressions.create({
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.suppressions.create({
@@ -75,8 +75,7 @@ Deletes suppression entry associated with the account based on the specified rec
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Suppressions } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Suppressions } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const suppressions = new Suppressions(mailchannels)
@@ -86,6 +85,7 @@ const { success } = await suppressions.delete("name@example.com", "api")
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.suppressions.delete("name@example.com", "api")
@@ -112,8 +112,7 @@ Retrieve suppression entries associated with the specified account. Supports fil
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Suppressions } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Suppressions } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const suppressions = new Suppressions(mailchannels)
@@ -123,6 +122,7 @@ const { list } = await suppressions.list()
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { list } = await mailchannels.suppressions.list()

--- a/docs/modules/users.md
+++ b/docs/modules/users.md
@@ -16,8 +16,7 @@ Create a recipient user.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Users } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Users } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const users = new Users(mailchannels)
@@ -29,6 +28,7 @@ const { user } = await users.create('name@example.com', {
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { user } = await mailchannels.users.create('name@example.com', {
@@ -74,8 +74,7 @@ Add an entry to a recipient user blocklist or safelist.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Users } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Users } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const users = new Users(mailchannels)
@@ -88,6 +87,7 @@ const { entry } = await users.addListEntry('name@example.com', {
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { entry } = await mailchannels.users.addListEntry('name@example.com', {
@@ -120,8 +120,7 @@ Get recipient list entries.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Users } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Users } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const users = new Users(mailchannels)
@@ -131,6 +130,7 @@ const { entries } = await users.listEntries('name@example.com', 'safelist')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { entries } = await mailchannels.users.listEntries('name@example.com', 'safelist')
@@ -158,8 +158,7 @@ Delete item from recipient list.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Users } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Users } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const users = new Users(mailchannels)
@@ -172,6 +171,7 @@ const { success } = await users.deleteListEntry('name@example.com', {
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.users.deleteListEntry('name@example.com', {

--- a/docs/modules/webhooks.md
+++ b/docs/modules/webhooks.md
@@ -16,8 +16,7 @@ Enrolls the user to receive event notifications via webhooks.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Webhooks } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Webhooks } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const webhooks = new Webhooks(mailchannels)
@@ -27,6 +26,7 @@ const { success } = await webhooks.enroll("https://example.com/api/webhooks/mail
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.webhooks.enroll("https://example.com/api/webhooks/mailchannels")
@@ -50,8 +50,7 @@ Lists all the webhook endpoints that are enrolled to receive event notifications
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Webhooks } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Webhooks } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const webhooks = new Webhooks(mailchannels)
@@ -61,6 +60,7 @@ const { webhooks: webhooksList } = await webhooks.list()
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { webhooks } = await mailchannels.webhooks.list()
@@ -81,8 +81,7 @@ Deletes all registered webhook endpoints for the user.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Webhooks } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Webhooks } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const webhooks = new Webhooks(mailchannels)
@@ -92,6 +91,7 @@ const { success } = await webhooks.delete()
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { success } = await mailchannels.webhooks.delete()
@@ -111,8 +111,7 @@ Retrieves the public key used to verify signatures on incoming webhook payloads.
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Webhooks } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Webhooks } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const webhooks = new Webhooks(mailchannels)
@@ -122,6 +121,7 @@ const { key } = await webhooks.getSigningKey('key-id')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { key } = await mailchannels.webhooks.getSigningKey('key-id')
@@ -148,8 +148,7 @@ Validates whether your enrolled webhook(s) respond with an HTTP `2xx` status cod
 
 ::: code-group
 ```ts [modular.ts]
-import { MailChannelsClient } from 'mailchannels-sdk'
-import { Webhooks } from 'mailchannels-sdk/modules'
+import { MailChannelsClient, Webhooks } from 'mailchannels-sdk'
 
 const mailchannels = new MailChannelsClient('your-api-key')
 const webhooks = new Webhooks(mailchannels)
@@ -159,6 +158,7 @@ const { allPassed, results } = await webhooks.validate('optional-request-id')
 
 ```ts [full.ts]
 import { MailChannels } from 'mailchannels-sdk'
+
 const mailchannels = new MailChannels('your-api-key')
 
 const { allPassed, results } = await mailchannels.webhooks.validate('optional-request-id')

--- a/package.json
+++ b/package.json
@@ -27,10 +27,6 @@
     ".": {
       "types": "./dist/mailchannels.d.mts",
       "import": "./dist/mailchannels.mjs"
-    },
-    "./modules": {
-      "types": "./dist/modules.d.mts",
-      "import": "./dist/modules.mjs"
     }
   },
   "types": "./dist/mailchannels.d.ts",

--- a/src/mailchannels.ts
+++ b/src/mailchannels.ts
@@ -2,6 +2,7 @@ import { MailChannelsClient } from "./client";
 import { Domains, Emails, Lists, Metrics, Service, SubAccounts, Suppressions, Users, Webhooks } from "./modules";
 
 export { MailChannelsClient };
+export * from "./modules";
 export type * from "./types";
 
 export class MailChannels extends MailChannelsClient {

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -10,6 +10,3 @@ export { Domains } from "./modules/domains";
 export { Lists } from "./modules/lists";
 export { Users } from "./modules/users";
 export { Service } from "./modules/service";
-
-// Types
-export type * from "./types";


### PR DESCRIPTION
Consolidates all module exports into the main entry point by removing the separate `mailchannels-sdk/modules` export. Updates documentation to use named imports from `mailchannels-sdk` instead of subpath imports.