### PR TITLE
feat(webhooks): add `resendBatch` method

### DIFF
--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -47,7 +47,8 @@ export default [
               { text: "Get Signing Key", link: "/modules/webhooks/get-signing-key" },
               { text: "Validate Webhooks", link: "/modules/webhooks/validate" },
               { text: "Verify a message", link: "/modules/webhooks/verify" },
-              { text: "Retrieve Webhook Batches", link: "/modules/webhooks/batches" }
+              { text: "Retrieve Webhook Batches", link: "/modules/webhooks/batches" },
+              { text: "Resend Batch", link: "/modules/webhooks/resend-batch" }
             ]
           },
           {

--- a/docs/modules/webhooks/index.md
+++ b/docs/modules/webhooks/index.md
@@ -48,4 +48,9 @@ Receive notifications of your email events via webhooks.
   <<< @/snippets/webhooks-batch-response-status.ts
   <<< @/snippets/webhooks-batch.ts
   <<< @/snippets/webhooks-batches-response.ts
+
+  **Resend Batch type declarations**
+
+  <<< @/snippets/webhooks-resend-batch.ts
+  <<< @/snippets/webhooks-resend-batch-response.ts
 </details>

--- a/docs/modules/webhooks/resend-batch.md
+++ b/docs/modules/webhooks/resend-batch.md
@@ -1,0 +1,61 @@
+---
+title: Resend Batch
+titleTemplate: 📢 Webhooks
+---
+
+# Resend Batch<llm-exclude> <Badge type="info">method</Badge> <Badge><a href="/modules/webhooks">📢 Webhooks</a></Badge></llm-exclude>
+
+Synchronously resends the webhook batch with the provided `batchId` for the customer. The result is returned in the response.
+
+## Usage
+
+::: code-group
+```ts [modular.ts]
+import { MailChannelsClient, Webhooks } from 'mailchannels-sdk'
+
+const mailchannels = new MailChannelsClient('your-api-key')
+const webhooks = new Webhooks(mailchannels)
+
+const { data, error } = await webhooks.resendBatch(123)
+```
+
+```ts [full.ts]
+import { MailChannels } from 'mailchannels-sdk'
+
+const mailchannels = new MailChannels('your-api-key')
+
+const { data, error } = await mailchannels.webhooks.resendBatch(123)
+```
+:::
+
+## Params
+
+- `batchId` `number` <Badge>guaranteed</Badge>: Unique identifier for the webhook batch.
+
+## Response
+
+- `data` `WebhooksResendBatch | null` <Badge type="warning">nullable</Badge>
+  - `batchId` `number` <Badge>guaranteed</Badge>: Unique identifier for the webhook batch.
+  - `createdAt` `string` <Badge>guaranteed</Badge>: Timestamp of when the webhook batch was created.
+  - `customerHandle` `string` <Badge>guaranteed</Badge>: The customer handle associated with the webhook batch.
+  - `duration` `number | null` <Badge type="warning">nullable</Badge>: Duration of the webhook batch in milliseconds. `null` indicates that no response was returned from the webhook endpoint.
+  - `eventCount` `number` <Badge>guaranteed</Badge>: Number of events in the webhook batch.
+  - `statusCode` `number | null` <Badge type="warning">nullable</Badge>: HTTP status code returned by the webhook endpoint.
+  - `webhook` `string` <Badge>guaranteed</Badge>: Webhook endpoint to which events in the batch were posted.
+<!-- @include: ../_parts/error-response.md -->
+
+## Type declarations
+
+**Signature**
+
+<<< @/snippets/webhooks-method-resend-batch.ts
+
+**Response type declarations**
+
+<<< @/snippets/error-response.ts
+<<< @/snippets/data-response.ts
+
+**Resend Batch type declarations**
+
+<<< @/snippets/webhooks-resend-batch.ts
+<<< @/snippets/webhooks-resend-batch-response.ts

--- a/docs/sdk-api-mapping.md
+++ b/docs/sdk-api-mapping.md
@@ -27,6 +27,7 @@ This page provides a mapping between the MailChannels SDK module methods and the
   | [`Webhooks.validate()`](/modules/webhooks/validate) | [Validate Enrolled Webhook](https://docs.mailchannels.net/email-api/api-reference/validate-enrolled-webhook) |
   | [`Webhooks.verify()`](/modules/webhooks/verify) | SDK only |
   | [`Webhooks.batches()`](/modules/webhooks/batches) | [Retrieve Webhook Batches](https://docs.mailchannels.net/email-api/api-reference/retrieve-webhook-batches) |
+  | [`Webhooks.resendBatch()`](/modules/webhooks/resend-batch) | [Resend Events](https://docs.mailchannels.net/email-api/api-reference/resend-events) |
 
 ### 🪪 Sub-accounts
 

--- a/playground/webhooks/resend-batch.ts
+++ b/playground/webhooks/resend-batch.ts
@@ -1,0 +1,16 @@
+import { MailChannels } from "../../src/mailchannels";
+
+process.loadEnvFile();
+
+const {
+  MAILCHANNELS_API_KEY: apiKey
+} = process.env;
+
+if (!apiKey) {
+  throw new Error("Missing environment variables");
+}
+
+const mailchannels = new MailChannels(apiKey);
+const { data, error } = await mailchannels.webhooks.resendBatch(13509);
+
+console.info(JSON.stringify({ data, error }, null, 2));

--- a/scripts/email-api-simulator.mjs
+++ b/scripts/email-api-simulator.mjs
@@ -512,10 +512,12 @@ export const createEmailApiSimulator = ({ host = DEFAULT_HOST, logRequests = tru
           batch_id: batch.batch_id,
           customer_handle: account.customerHandle,
           webhook: batch.webhook,
+          created_at: currentTimestamp(),
           status_code: 200,
           duration_in_ms: 25,
           event_count: batch.event_count
         });
+        return;
       }
 
       if (url.pathname === "/tx/v1/sub-account" && method === "POST") {

--- a/scripts/email-api-simulator.mjs
+++ b/scripts/email-api-simulator.mjs
@@ -503,7 +503,7 @@ export const createEmailApiSimulator = ({ host = DEFAULT_HOST, logRequests = tru
         const batchId = Number(webhookBatchResendMatch[1]);
         const batch = account.webhookBatches.find(batch => batch.batch_id === batchId);
         if (!batch) {
-          sendJson(response, 404, { error: "Specified batch not found." });
+          sendJson(response, 404, { error: "webhook not found." });
           return;
         }
 

--- a/scripts/email-api-simulator.mjs
+++ b/scripts/email-api-simulator.mjs
@@ -498,6 +498,26 @@ export const createEmailApiSimulator = ({ host = DEFAULT_HOST, logRequests = tru
         return;
       }
 
+      const webhookBatchResendMatch = url.pathname.match(/^\/tx\/v1\/webhook-batch\/(\d+)\/resend$/);
+      if (webhookBatchResendMatch && method === "POST") {
+        const batchId = Number(webhookBatchResendMatch[1]);
+        const batch = account.webhookBatches.find(batch => batch.batch_id === batchId);
+        if (!batch) {
+          sendJson(response, 404, { error: "Specified batch not found." });
+          return;
+        }
+
+        recordWebhookBatch(account, batch.webhook, batch.event_count);
+        sendJson(response, 200, {
+          batch_id: batch.batch_id,
+          customer_handle: account.customerHandle,
+          webhook: batch.webhook,
+          status_code: 200,
+          duration_in_ms: 25,
+          event_count: batch.event_count
+        });
+      }
+
       if (url.pathname === "/tx/v1/sub-account" && method === "POST") {
         const subAccount = createSubAccount(account, body?.company_name || "Simulator Company", body?.handle);
         account.subAccounts.set(subAccount.handle, subAccount);

--- a/scripts/generate-parity-fixtures.mjs
+++ b/scripts/generate-parity-fixtures.mjs
@@ -50,7 +50,8 @@ const emailMethodMap = {
   "POST /webhook": { module: "webhooks", method: "enroll" },
   "GET /webhook-batch": { module: "webhooks", method: "batches" },
   "GET /webhook/public-key": { module: "webhooks", method: "getSigningKey" },
-  "POST /webhook/validate": { module: "webhooks", method: "validate" }
+  "POST /webhook/validate": { module: "webhooks", method: "validate" },
+  "POST /webhook-batch/{batch_id}/resend": { module: "webhooks", method: "resendBatch" }
 };
 
 const inboundMethodMap = {

--- a/src/modules/webhooks.ts
+++ b/src/modules/webhooks.ts
@@ -288,7 +288,6 @@ export class Webhooks {
   /**
    * Synchronously resends the webhook batch with the provided `batchId` for the customer. The result is returned in the response.
    * @param batchId - The ID of the batch to resend.
-   * @param customerHandle - The handle of the customer who owns the batch.
    * @example
    * ```ts
    * const mailchannels = new MailChannels('your-api-key')

--- a/src/modules/webhooks.ts
+++ b/src/modules/webhooks.ts
@@ -8,7 +8,8 @@ import type { WebhooksSigningKeyResponse } from "../types/webhooks/signing-key";
 import type { WebhooksValidateResponse } from "../types/webhooks/validate";
 import type { WebhooksVerifyOptions } from "../types/webhooks/verify";
 import type { WebhooksBatchesOptions, WebhooksBatchesResponse } from "../types/webhooks/batches";
-import type { WebhooksBatchesApiResponse, WebhooksValidateApiResponse } from "../types/webhooks/internal";
+import type { WebhooksResendBatchResponse } from "../types/webhooks/resend-batch";
+import type { WebhooksBatchesApiResponse, WebhooksResendBatchApiResponse, WebhooksValidateApiResponse } from "../types/webhooks/internal";
 
 export class Webhooks {
   constructor (protected mailchannels: MailChannelsClient) {}
@@ -280,6 +281,46 @@ export class Webhooks {
       statusCode: batch.status_code,
       webhook: batch.webhook
     })));
+
+    return { data, error: null };
+  }
+
+  /**
+   * Synchronously resends the webhook batch with the provided `batchId` for the customer. The result is returned in the response.
+   * @param batchId - The ID of the batch to resend.
+   * @param customerHandle - The handle of the customer who owns the batch.
+   * @example
+   * ```ts
+   * const mailchannels = new MailChannels('your-api-key')
+   * const { data, error } = await mailchannels.webhooks.resendBatch(123)
+   * ```
+   */
+  async resendBatch (batchId: number): Promise<WebhooksResendBatchResponse> {
+    let error: ErrorResponse | null = null;
+
+    const response = await this.mailchannels.post<WebhooksResendBatchApiResponse>(`/tx/v1/webhook-batch/${batchId}/resend`, {
+      onResponseError: async ({ response }) => {
+        error = getStatusError(response, {
+          [ErrorCode.BadRequest]: "Bad Request. The batch ID is invalid.",
+          [ErrorCode.NotFound]: `The batch '${batchId}' is not found for the customer.`
+        });
+      }
+    }).catch((e) => {
+      error ||= getResultError(e, "Failed to resend webhook batch.");
+      return null;
+    });
+
+    if (!response) return { data: null, error: error! };
+
+    const data = clean({
+      batchId: response.batch_id,
+      customerHandle: response.customer_handle,
+      webhook: response.webhook,
+      createdAt: response.created_at,
+      eventCount: response.event_count,
+      duration: response.duration_in_ms,
+      statusCode: response.status_code
+    });
 
     return { data, error: null };
   }

--- a/src/types/webhooks/index.ts
+++ b/src/types/webhooks/index.ts
@@ -4,3 +4,4 @@ export * from "./validate";
 export * from "./events";
 export * from "./verify";
 export * from "./batches";
+export * from "./resend-batch";

--- a/src/types/webhooks/internal.ts
+++ b/src/types/webhooks/internal.ts
@@ -25,3 +25,13 @@ export interface WebhooksBatchesApiResponse {
     webhook: string;
   }[];
 }
+
+export interface WebhooksResendBatchApiResponse {
+  batch_id: number;
+  customer_handle: string;
+  webhook: string;
+  created_at: string;
+  event_count: number;
+  duration_in_ms: number | null;
+  status_code: number | null;
+}

--- a/src/types/webhooks/resend-batch.ts
+++ b/src/types/webhooks/resend-batch.ts
@@ -1,0 +1,34 @@
+import type { DataResponse } from "../responses";
+
+export interface WebhooksResendBatch {
+  /**
+   * Unique identifier for the webhook batch.
+   */
+  batchId: number;
+  /**
+   * Customer handle associated with the webhook batch.
+   */
+  customerHandle: string;
+  /**
+   * Webhook URL to which events in the batch were posted.
+   */
+  webhook: string;
+  /**
+   * Timestamp of when the webhook batch was created.
+   */
+  createdAt: string;
+  /**
+   * Number of events in the webhook batch.
+   */
+  eventCount: number;
+  /**
+   * Duration of the webhook batch in milliseconds. `null` indicates that no response was returned from the webhook endpoint.
+   */
+  duration: number | null;
+  /**
+   * HTTP status code returned by the webhook endpoint. `null` indicates that no response was returned from the webhook endpoint.
+   */
+  statusCode: number | null;
+}
+
+export type WebhooksResendBatchResponse = DataResponse<WebhooksResendBatch>;

--- a/test/fixtures/email-api-endpoints.json
+++ b/test/fixtures/email-api-endpoints.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.19.0",
+  "version": "0.20.0",
   "endpoints": [
     {
       "module": "emails",
@@ -210,6 +210,12 @@
       "method": "batches",
       "httpMethod": "GET",
       "path": "/webhook-batch"
+    },
+    {
+      "module": "webhooks",
+      "method": "resendBatch",
+      "httpMethod": "POST",
+      "path": "/webhook-batch/{batch_id}/resend"
     },
     {
       "module": "webhooks",

--- a/test/modules/webhooks/resend-batch.test.ts
+++ b/test/modules/webhooks/resend-batch.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MailChannelsClient } from "~/client";
+import { Webhooks } from "~/modules/webhooks";
+import { ErrorCode } from "~/utils/errors";
+import type { WebhooksResendBatchApiResponse } from "~/types/webhooks/internal";
+import type { WebhooksResendBatchResponse } from "~/types/webhooks/resend-batch";
+
+const fake = {
+  batchId: 123,
+  apiResponse: {
+    batch_id: 123,
+    customer_handle: "test",
+    webhook: "https://127.0.0.1/webhooks",
+    status_code: 200,
+    duration_in_ms: 1294,
+    created_at: "2026-04-10T03:34:27.511881626Z",
+    event_count: 2
+  } satisfies WebhooksResendBatchApiResponse,
+  expectedResponse: {
+    data:
+      {
+        batchId: 123,
+        customerHandle: "test",
+        webhook: "https://127.0.0.1/webhooks",
+        createdAt: "2026-04-10T03:34:27.511881626Z",
+        eventCount: 2,
+        duration: 1294,
+        statusCode: 200
+      },
+    error: null
+  } satisfies WebhooksResendBatchResponse
+};
+
+describe("resend-batch", () => {
+  it("should successfully resend webhook batch", async () => {
+    const mockClient = {
+      post: vi.fn().mockResolvedValueOnce(fake.apiResponse)
+    } as unknown as MailChannelsClient;
+
+    const webhooks = new Webhooks(mockClient);
+    const { data, error } = await webhooks.resendBatch(fake.batchId);
+
+    expect(data).toStrictEqual(fake.expectedResponse.data);
+    expect(error).toBeNull();
+    expect(mockClient.post).toHaveBeenCalled();
+  });
+
+  it("should contain error on api response error", async () => {
+    const mockClient = {
+      post: vi.fn().mockImplementationOnce(async (url, { onResponseError }) => new Promise((_, reject) => {
+        onResponseError({ response: { status: ErrorCode.BadRequest } });
+        reject();
+      }))
+    } as unknown as MailChannelsClient;
+
+    const webhooks = new Webhooks(mockClient);
+    const { data, error } = await webhooks.resendBatch(fake.batchId);
+
+    expect(error).toBeTruthy();
+    expect(data).toBeNull();
+    expect(mockClient.post).toHaveBeenCalled();
+  });
+
+  it("should handle catch block errors", async () => {
+    const mockClient = {
+      post: vi.fn().mockRejectedValueOnce(new Error("failure"))
+    } as unknown as MailChannelsClient;
+
+    const webhooks = new Webhooks(mockClient);
+    const { data, error } = await webhooks.resendBatch(fake.batchId);
+
+    expect(error).toStrictEqual({ message: "failure", statusCode: null });
+    expect(data).toBeNull();
+    expect(mockClient.post).toHaveBeenCalled();
+  });
+
+  it("should handle catch block with non-Error rejections", async () => {
+    const mockClient = {
+      post: vi.fn().mockRejectedValueOnce("error")
+    } as unknown as MailChannelsClient;
+
+    const webhooks = new Webhooks(mockClient);
+    const { data, error } = await webhooks.resendBatch(fake.batchId);
+
+    expect(error).toStrictEqual({ message: "Failed to resend webhook batch.", statusCode: null });
+    expect(data).toBeNull();
+    expect(mockClient.post).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
- [x] Add `resendBatch` method to the `Webhooks` class
- [x] Add method JSDocs
- [x] Add type definitions
- [x] Add method in `scripts/generate-parity-fixtures.mjs`, then run `pnpm parity:fixtures`
- [x] Add endpoint in `scripts/email-api-simulator.mjs`
- [x] Playground: Add playground file
- [x] Test: Add `test/modules/webhooks/resend-batch.test.ts`
- [x] Docs: Run `pnpm docs:snippets` 
- [x] Docs: Add to Sidebar
- [x] Docs: Add method page
- [x] Docs: Add types to module page
