### PR TITLE
feat(emails): add SPF record response fields to `checkDomain`

### DIFF
--- a/docs/modules/emails/check-domain.md
+++ b/docs/modules/emails/check-domain.md
@@ -87,6 +87,8 @@ const { data, error } = await mailchannels.emails.checkDomain({
       - `verdict` `"passed" | "failed"` <Badge>guaranteed</Badge>
   - `spf` `object` <Badge>guaranteed</Badge>
     - `reason` `string` <Badge type="info">optional</Badge>: A human-readable explanation of SPF check.
+    - `spfRecord` `string` <Badge type="info">optional</Badge>: The SPF record that was used for the check.
+    - `spfRecordError` `string` <Badge type="info">optional</Badge>: Error message if the SPF record lookup failed.
     - `verdict` `"passed" | "failed" | "soft failed" | "temporary error" | "permanent error" | "neutral" | "none" | "unknown"` <Badge>guaranteed</Badge>
   - `references` `string[]` <Badge type="info">optional</Badge>
 <!-- @include: ../_parts/error-response.md -->

--- a/src/types/emails/check-domain.ts
+++ b/src/types/emails/check-domain.ts
@@ -88,6 +88,14 @@ export type EmailsCheckDomainResponse = DataResponse<{
      * A human-readable explanation of SPF check.
      */
     reason?: string;
+    /**
+     * The SPF record that was used for the check.
+     */
+    spfRecord?: string;
+    /**
+     * Error message if the SPF record lookup failed.
+     */
+    spfRecordError?: string;
     verdict: EmailsCheckDomainVerdict;
   };
   references?: string[];

--- a/src/types/emails/internal.ts
+++ b/src/types/emails/internal.ts
@@ -99,6 +99,8 @@ export interface EmailsCheckDomainApiResponse {
     };
     spf: {
       reason?: string;
+      spfRecord?: string;
+      spfRecordError?: string;
       verdict: EmailsCheckDomainVerdict;
     };
   };

--- a/test/fixtures/email-api-endpoints.json
+++ b/test/fixtures/email-api-endpoints.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.20.0",
+  "version": "0.21.0",
   "endpoints": [
     {
       "module": "emails",

--- a/test/modules/emails/check-domain.test.ts
+++ b/test/modules/emails/check-domain.test.ts
@@ -7,7 +7,10 @@ import type { EmailsCheckDomainResponse } from "~/types/emails/check-domain";
 const fake = {
   apiResponse: {
     check_results: {
-      spf: { verdict: "passed" },
+      spf: {
+        verdict: "passed",
+        spfRecord: "v=spf1 include:relay.mailchannels.net a mx ~all"
+      },
       domain_lockdown: { verdict: "passed" },
       sender_domain: { a: { verdict: "failed" }, mx: { verdict: "passed" }, verdict: "passed" },
       dkim: [{ dkim_domain: "example.com", dkim_key_status: "provided", dkim_selector: "selector", verdict: "passed" }]
@@ -15,7 +18,10 @@ const fake = {
   },
   expectedResponse: {
     data: {
-      spf: { verdict: "passed" },
+      spf: {
+        verdict: "passed",
+        spfRecord: "v=spf1 include:relay.mailchannels.net a mx ~all"
+      },
       domainLockdown: { verdict: "passed" },
       senderDomain: { a: { verdict: "failed" }, mx: { verdict: "passed" }, verdict: "passed" },
       dkim: [{ domain: "example.com", keyStatus: "provided", selector: "selector", verdict: "passed" }]


### PR DESCRIPTION
**SPF Check Enhancements:**

* Added `spfRecord` (the SPF record used for the check) and `spfRecordError` (error message if SPF record lookup failed) to the SPF check result in the API response types (`EmailsCheckDomainResponse`, `EmailsCheckDomainApiResponse`). [[1]](diffhunk://#diff-45b65080018c8232579b2ff48d8a2b77479942e904c2dcae3dc787c5ffeb282fR91-R98) [[2]](diffhunk://#diff-4c8b22ea323e8ece9ff813df3fd0ce0a27cb556075b4a3d785b82f472cdd2b50R102-R103)
* Updated the documentation to describe the new `spfRecord` and `spfRecordError` fields for the SPF check object.

**Testing Updates:**

* Modified the test fixtures in `check-domain.test.ts` to include the new `spfRecord` field, ensuring the tests cover the updated response structure.