### PR TITLE
feat: add `User-Agent` header

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,5 @@
 import { $fetch, type FetchOptions } from "ofetch";
+import { version } from "../package.json";
 
 export interface MailChannelsClientOptions {
   /**
@@ -23,7 +24,8 @@ export class MailChannelsClient {
     this.#headers = {
       "X-API-Key": key,
       "Accept": "application/json",
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
+      "User-Agent": `mailchannels-node/${version}`
     };
   }
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { $fetch } from "ofetch";
 import { MailChannelsClient } from "../src/client";
+import { version } from "../package.json";
 
 const fake = {
   baseURL: "https://api.mailchannels.net",
@@ -9,7 +10,8 @@ const fake = {
   apiKey: "test-api-key",
   headers: {
     "Accept": "application/json",
-    "Content-Type": "application/json"
+    "Content-Type": "application/json",
+    "User-Agent": `mailchannels-node/${version}`
   }
 };
 


### PR DESCRIPTION
**Update:**

* Added a `User-Agent` header to all requests sent by `MailChannelsClient`, using the format `mailchannels-node/<version>` sourced from `package.json`. [[1]](diffhunk://#diff-25d66d74617fe2e23d7946bd6e3ba95640ab1b9bc8947445d604fc271c7c1f12R2) [[2]](diffhunk://#diff-25d66d74617fe2e23d7946bd6e3ba95640ab1b9bc8947445d604fc271c7c1f12L26-R28)

**Test updates:**

* Updated the test fixture in `client.test.ts` to include the new `User-Agent` header. [[1]](diffhunk://#diff-d02780c2f062abcf8505db670090d74c454de33dcf58974ba92e68db603208a2R4) [[2]](diffhunk://#diff-d02780c2f062abcf8505db670090d74c454de33dcf58974ba92e68db603208a2L12-R14)